### PR TITLE
Address issue where a charm wouldn't download its resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # cdk-shrinkwrap
-[![Test Suite](https://github.com/charmed-kubernetes/cdk-shrinkwrap/actions/workflows/main.yml/badge.svg)](https://github.com/charmed-kubernetes/cdk-shrinkwrap/actions/workflows/main.yml)
+[![Test Suite](https://github.com/charmed-kubernetes/cdk-shrinkwrap/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/charmed-kubernetes/cdk-shrinkwrap/actions/workflows/main.yml)
+[![codecov](https://codecov.io/gh/charmed-kubernetes/cdk-shrinkwrap/branch/master/graph/badge.svg?token=rI9OruOCKk)](https://codecov.io/gh/charmed-kubernetes/cdk-shrinkwrap)
 
 
 Builds a tarball of charms, resources, containers, snap-store-proxy tarballs, and a deploy script for offline installs.

--- a/shrinkwrap-lxc.sh
+++ b/shrinkwrap-lxc.sh
@@ -1,8 +1,7 @@
 #!/bin/bash
 
-lxc launch ubuntu:20.04 shrinkwrap
-# Required to run docker daemon in lxc (for a local docker registry)
-lxc config set shrinkwrap security.privileged true
+# LXC Requires privileged to run docker daemon
+lxc launch ubuntu:20.04 shrinkwrap -c security.privileged=true
 lxc file push ./shrinkwrap.py shrinkwrap/root/
 lxc file push ./requirements.txt shrinkwrap/root/
 sleep 2

--- a/shrinkwrap.py
+++ b/shrinkwrap.py
@@ -2,6 +2,7 @@
 
 import argparse
 import datetime
+from contextlib import contextmanager
 import os
 from pathlib import Path
 import re
@@ -17,6 +18,13 @@ import semver
 import yaml
 
 shlx = shlex.split
+
+
+@contextmanager
+def status(msg):
+    sys.stdout.write(f"    {msg} ... ")
+    yield
+    print("done")
 
 
 def remove_prefix(str_o, prefix):
@@ -123,32 +131,30 @@ class BundleDownloader(Downloader):
         if ch:
             channel = app.get("channel")
             self._charmhub_downloader(appname, remove_prefix(charm, "ch:"), channel=channel)
-            charm_id = charm
         else:
             self._charmstore_downloader(appname, remove_prefix(charm, "cs:"))
-            charm_id = charm.rpartition("-")[0]
-        return charm_id
+        return charm
 
     def _charmhub_downloader(self, name, resource, channel=None, arch=None):
-        print(f'    Downloading "{resource}" from charm hub...')
-        download_args, rsc_target = self.to_args(self.path / name, channel, arch)
-        rsc_target.mkdir(parents=True, exist_ok=True)
-        check_output(
-            shlx(f"juju download {resource}{download_args} --filepath /tmp/archive.zip"),
-            stderr=STDOUT,
-        )
+        with status(f'    Downloading "{resource}" from charm hub'):
+            download_args, rsc_target = self.to_args(self.path / name, channel, arch)
+            rsc_target.mkdir(parents=True, exist_ok=True)
+            check_output(
+                shlx(f"juju download {resource}{download_args} --filepath /tmp/archive.zip"),
+                stderr=STDOUT,
+            )
         check_call(shlx(f"unzip -qq /tmp/archive.zip -d {rsc_target}"))
         check_call(shlx("rm /tmp/archive.zip"))
         return rsc_target
 
     def _charmstore_downloader(self, name, resource):
-        print(f'    Downloading "{resource}" from charm store...')
-        charmstore_url = "https://api.jujucharms.com/charmstore/v5"
-        check_call(shlx(f"wget --quiet {charmstore_url}/{resource}/archive -O /tmp/archive.zip"))
-        rsc_target = self.path / name
-        rsc_target.mkdir(parents=True, exist_ok=True)
-        check_call(shlx(f"unzip -qq /tmp/archive.zip -d {rsc_target}"))
-        check_call(shlx("rm /tmp/archive.zip"))
+        with status(f'    Downloading "{resource}" from charm store'):
+            charmstore_url = "https://api.jujucharms.com/charmstore/v5"
+            check_call(shlx(f"wget --quiet {charmstore_url}/{resource}/archive -O /tmp/archive.zip"))
+            rsc_target = self.path / name
+            rsc_target.mkdir(parents=True, exist_ok=True)
+            check_call(shlx(f"unzip -qq /tmp/archive.zip -d {rsc_target}"))
+            check_call(shlx("rm /tmp/archive.zip"))
         return rsc_target
 
 
@@ -172,10 +178,9 @@ class OverlayDownloader(Downloader):
 
     def download(self, overlay):
         overlay_url = self.list[overlay]
-        sys.stdout.write(f'    Downloading "{overlay}" from {overlay_url} ...')
-        with (self.path / overlay).open("w") as fp:
-            fp.write(requests.get(overlay_url).text)
-        print("Done")
+        with status(f'    Downloading "{overlay_url}" from github'):
+            with (self.path / overlay).open("w") as fp:
+                fp.write(requests.get(overlay_url).text)
 
 
 class ContainerDownloader(Downloader):
@@ -220,13 +225,12 @@ class ContainerDownloader(Downloader):
         target = Path(f"{self.path / image}.tar.gz")
         target.parent.mkdir(parents=True, exist_ok=True)
         with target.open("wb") as fp:
-            sys.stdout.write(f'    Downloading "{image}" from {self.IMAGE_REPO}...')
-            check_call(shlx(f"docker pull -q {image_src}"))
-            p1 = Popen(shlx(f"docker save {image_src}"), stdout=PIPE)
-            p2 = Popen(shlx("gzip"), stdin=p1.stdout, stdout=fp)
-            p1.stdout.close()
-            p2.communicate()
-            print("done")
+            with status(f'    Downloading "{image}" from {self.IMAGE_REPO}'):
+                check_call(shlx(f"docker pull -q {image_src}"))
+                p1 = Popen(shlx(f"docker save {image_src}"), stdout=PIPE)
+                p2 = Popen(shlx("gzip"), stdin=p1.stdout, stdout=fp)
+                p1.stdout.close()
+                p2.communicate()
 
     def _image_delete(self, image):
         image_src = f"{self.IMAGE_REPO}{image}"
@@ -236,8 +240,9 @@ class ContainerDownloader(Downloader):
         revisions = self.revisions(channel)
         assert revisions, f"No revisions matched the channel {channel}"
         _, latest_url = revisions[-1]
-        print(f'    Downloading "{latest_url}" from github...')
-        images = requests.get(latest_url).text.splitlines()
+
+        with status(f'    Downloading "{latest_url}" from github'):
+            images = requests.get(latest_url).text.splitlines()
         for container_image in images:
             self._image_save(container_image)
         for container_image in images:
@@ -269,12 +274,11 @@ class SnapDownloader(Downloader):
     def download(self, snap, channel, arch) -> Path:
         snap_key = (snap, channel, arch)
         if snap_key not in self._downloaded:
-            sys.stdout.write(f'    Downloading snap "{snap}" from snap store...')
-            download_args, snap_target = self.to_args(self.path / snap, channel, arch)
-            snap_target.mkdir(parents=True, exist_ok=True)
-            tgz = self._fetch_snap(snap, download_args)
-            check_call(shlx(f"mv {tgz} {snap_target}"))
-            print("done")
+            with status(f'    Downloading snap "{snap}" from snap store'):
+                download_args, snap_target = self.to_args(self.path / snap, channel, arch)
+                snap_target.mkdir(parents=True, exist_ok=True)
+                tgz = self._fetch_snap(snap, download_args)
+                check_call(shlx(f"mv {tgz} {snap_target}"))
             self._downloaded[snap_key] = snap_target
         return self._downloaded[snap_key]
 
@@ -301,8 +305,8 @@ class ResourceDownloader(Downloader):
             raise NotImplementedError("Charmhub doesn't support fetching resources")
         else:
             url = f"{self.URL}/{remove_prefix(charm, 'cs:')}/resource/{name}/{revision}"
-            print(f"    Downloading resource {name} from charm store revision {revision}...")
-            check_call(shlx(f"wget --quiet {url} -O {target}"))
+            with status(f"    Downloading resource {name} from charm store revision {revision}"):
+                check_call(shlx(f"wget --quiet {url} -O {target}"))
         return target
 
 
@@ -338,7 +342,7 @@ def download(args, root):
         charm = charms.app_download(app_name, app)
 
         app_channel = charm_channel(app, root / "charms" / app_name)
-        if charm.endswith("kubernetes-master"):
+        if "kubernetes-master" in charm:
             k8s_master_channel = app_channel
 
         # Download each resource or snap.
@@ -473,15 +477,13 @@ def main():
         bundle = BundleDownloader(root, args)
 
     # Generate a new bundle.yaml for deployment
-    sys.stdout.write("Writing offline bundle.yaml ...")
-    build_offline_bundle(root, bundle)
-    print("done")
+    with status("Writing offline bundle.yaml"):
+        build_offline_bundle(root, bundle)
 
     # Make the tarball.
-    sys.stdout.write("Writing tarball ...")
-    check_call(shlx(f'tar -czf {root}.tar.gz -C build/ {root.relative_to("build")} --force-local'))
-    shutil.rmtree(root)
-    print("done")
+    with status("Writing tarball"):
+        check_call(shlx(f'tar -czf {root}.tar.gz -C build/ {root.relative_to("build")} --force-local'))
+        shutil.rmtree(root)
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_bundle_downloader.py
+++ b/tests/unit/test_bundle_downloader.py
@@ -32,8 +32,11 @@ def test_bundle_downloader(tmp_dir, mock_ch_downloader, mock_cs_downloader):
     downloader = BundleDownloader(tmp_dir, args)
     assert downloader.bundle_path == Path(tmp_dir) / "charms" / ".bundle"
 
-    downloader.app_download("etcd", {"charm": "etcd", "channel": "latest/edge"})
-    downloader.app_download("containerd", {"charm": "cs:~containers/containerd-160"})
+    assert downloader.app_download("etcd", {"charm": "etcd", "channel": "latest/edge"}) == "etcd"
+    assert (
+        downloader.app_download("containerd", {"charm": "cs:~containers/containerd-160"})
+        == "cs:~containers/containerd-160"
+    )
     mock_ch_downloader.assert_called_once_with("etcd", "etcd", channel="latest/edge")
     mock_cs_downloader.assert_called_once_with("containerd", "~containers/containerd-160")
 
@@ -67,6 +70,7 @@ def test_bundle_downloader_properties(tmp_dir, mock_overlay_list):
     assert downloader.bundles["test-overlay.yaml"]["applications"].keys() == {
         "calico",
         "flannel",
+        "openstack-integrator",
     }
     assert downloader.applications.keys() == {
         "calico",
@@ -76,4 +80,5 @@ def test_bundle_downloader_properties(tmp_dir, mock_overlay_list):
         "flannel",
         "kubernetes-master",
         "kubernetes-worker",
+        "openstack-integrator",
     }

--- a/tests/unit/test_overlay.yaml
+++ b/tests/unit/test_overlay.yaml
@@ -1,5 +1,7 @@
 description: Charmed Kubernetes overlay for unit testing.
 applications:
+  openstack-integrator:
+    charm: cs:~containers/openstack-integrator
   calico:
     charm: cs:~containers/calico
   flannel:


### PR DESCRIPTION
if a hyphen appeared in its charm-name without a charm revision number, then shrinwrap failed to parse it's charm name. 
Resolved by not requiring that parsing at all.

* simplify the lxc creation script
* Added codecov badge
* created a wrapper to print the download status