### PR TITLE
Address issues with the charmhub provided bundle

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python: 
+          - "3.6"
+          - "3.7"
+          - "3.8"
+          - "3.9"
+          - "3.10"
     steps:
     - name: Check out code
       uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,24 +6,18 @@ on:
     branches: [ main ]
 
 jobs:
-  Inclusive-naming-check:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-      - name: woke
-        uses: canonical-web-and-design/inclusive-naming@main
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          reporter: github-pr-check
-          fail-on-error: true
+  call-inclusive-naming-check:
+    name: Inclusive Naming
+    uses: canonical-web-and-design/Inclusive-naming/.github/workflows/woke.yaml@main
+    with:
+      fail-on-error: "true"
 
   lint-unit:
     name: Lint, Unit
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: [3.6, 3.7, 3.8, 3.9]
+        python: [3.6, 3.7, 3.8, 3.9, 3.10]
     steps:
     - name: Check out code
       uses: actions/checkout@v2

--- a/shrinkwrap.py
+++ b/shrinkwrap.py
@@ -147,8 +147,9 @@ class BundleDownloader(StoreDownloader):
 
     def app_download(self, appname: str, app: dict):
         charm, channel = app["charm"], app.get("channel")
-        self._downloader(charm, Path(appname) / "metadata.yaml", channel)
-        return charm
+        _, app_target = self.to_args(Path(appname), channel)
+        path = self._downloader(charm, app_target / "metadata.yaml", channel)
+        return charm, path.parent
 
     def _downloader(self, name, path, channel):
         ch = name.startswith("ch:") or not name.startswith("cs:")
@@ -156,29 +157,28 @@ class BundleDownloader(StoreDownloader):
         target = self.path / path
         if target.exists():
             print(f'    Downloaded "{name}" already exists')
-            return
+            return target
 
-        target = target.parent
-        target.mkdir(parents=True, exist_ok=True)
+        extract = target.parent
+        extract.mkdir(parents=True, exist_ok=True)
         if ch:
-            return self._charmhub_downloader(name, target, channel=channel)
+            self._charmhub_downloader(name, extract, channel=channel)
         else:
-            return self._charmstore_downloader(name, target, channel=channel)
+            self._charmstore_downloader(name, extract, channel=channel)
+        return target
 
     def _charmhub_downloader(self, name, target, channel=None):
         with status(f'Downloading "{name} {channel}" from charm hub'):
-            _, rsc_target = self.to_args(target, channel)
             charm_info = self._charmhub_info(name, channel=channel, fields="default-release.revision.download.url")
             url = charm_info["default-release"]["revision"]["download"]["url"]
             resp = requests.get(url)
-            return zipfile.ZipFile(BytesIO(resp.content)).extractall(rsc_target)
+            zipfile.ZipFile(BytesIO(resp.content)).extractall(target)
 
     def _charmstore_downloader(self, name, target, channel=None):
         with status(f'Downloading "{name} {channel}" from charm store'):
-            _, rsc_target = self.to_args(target, channel=channel)
             url = f"{self.CS_URL}/{name}/archive"
             resp = requests.get(url, params={"channel": channel})
-            return zipfile.ZipFile(BytesIO(resp.content)).extractall(rsc_target)
+            zipfile.ZipFile(BytesIO(resp.content)).extractall(target)
 
 
 class OverlayDownloader(Downloader):
@@ -425,9 +425,8 @@ def download(args, root):
 
     # For each application, download the charm, resources, and snaps.
     for app_name, app in charms.applications.items():
-        charm = charms.app_download(app_name, app)
-
-        snap_channel = charm_snap_channel(app, root / "charms" / app_name)
+        charm, charm_path = charms.app_download(app_name, app)
+        snap_channel = charm_snap_channel(app, charm_path)
         charm_channel = app.get("channel")
         if charm in ["kubernetes-control-plane", "kubernetes-master"]:  # wokeignore:rule=master
             k8s_cp_channel = snap_channel
@@ -460,7 +459,8 @@ def download(args, root):
             else:
                 # This isn't a snap, pull the resource from the appropriate store
                 # use the bundle provided resource revision if available
-                resource_rev = app["resources"].get(resource.name) or resource.revision
+                resource_rev = app.get("resources", {}).get(resource.name)
+                resource_rev = resource_rev or resource.revision
                 resource = Resource(resource.name, resource.type, resource.path, resource_rev, resource.url_format)
                 resources.mark_download(app_name, charm, resource)
 
@@ -503,10 +503,18 @@ def build_offline_bundle(root, charms: BundleDownloader):
 
     def update_app(app_name, app):
         if app:
+            _, target = Downloader.to_args(root / "charms" / app_name, app.get("channel"))
+            # Load the resource definition from the current bundle if possible
+            # This will be a map of resource-name to resource numerical version
+            resources = app.get("resources")
+            if not resources:
+                # Load the resource from the local charm
+                # This will be a map of resource-name to resource metadata
+                resources = yaml.safe_load((target / "metadata.yaml").open()).get("resources", {})
             app.update(
                 {
-                    "charm": local_path(root / "charms" / app_name),
-                    "resources": update_resources(app_name, app.get("resources", {})),
+                    "charm": local_path(target),
+                    "resources": update_resources(app_name, resources),
                 }
             )
         return app

--- a/tests/unit/test_download_all.py
+++ b/tests/unit/test_download_all.py
@@ -19,6 +19,7 @@ def test_download_method(resource_list, resource_dl, snap_dl, app_dl, tmpdir, te
     args.skip_containers = False
     root = Path(tmpdir)
     app_name = "etcd"
+    etcd_path = root / "charms" / app_name
 
     with test_bundle.file.open() as fp:
         (root / "charms" / ".bundle").mkdir(parents=True)
@@ -29,10 +30,10 @@ def test_download_method(resource_list, resource_dl, snap_dl, app_dl, tmpdir, te
         (root / "charms" / ".bundle" / "bundle.yaml").write_text(yaml.safe_dump(whole_bundle))
 
     with test_charm_config.open() as fp:
-        (root / "charms" / app_name).mkdir(parents=True)
-        (root / "charms" / app_name / "config.yaml").write_text(fp.read())
+        etcd_path.mkdir(parents=True)
+        (etcd_path / "config.yaml").write_text(fp.read())
 
-    app_dl.return_value = "etcd"  # name of the charm, not the app
+    app_dl.return_value = app_name, etcd_path  # name of the charm, not the app
     resource_list.return_value = [
         Resource("core", "file", "core.snap", 0, "https://api.jujucharms.com/charmstore/v5/etcd/resource/core/0"),
         Resource("etcd", "file", "etcd.snap", 3, "https://api.jujucharms.com/charmstore/v5/etcd/resource/etcd/3"),
@@ -49,7 +50,7 @@ def test_download_method(resource_list, resource_dl, snap_dl, app_dl, tmpdir, te
     assert isinstance(charms, BundleDownloader)
 
     app_dl.assert_called_once_with(app_name, charms.applications[app_name])
-    resource_list.assert_called_once_with(app_dl.return_value, "latest/edge")
+    resource_list.assert_called_once_with(app_name, "latest/edge")
     snap_dl.assert_called_once()
     resource_dl.assert_called_once()
     assert (Path(tmpdir) / "resources" / "etcd" / "etcd" / "etcd.snap").is_symlink()

--- a/tox.ini
+++ b/tox.ini
@@ -30,7 +30,7 @@ commands = pytest \
           -s {posargs} \
           {toxinidir}/tests/unit
 
-[testenv:blacken]
+[testenv:format]
 deps = black
 commands = black --line-length 120 {toxinidir}/shrinkwrap.py {toxinidir}/tests
 


### PR DESCRIPTION
There seem to now be cases where the provided charmhub bundle doesn't specifically nail down the resources, but rather those resources are released with the charm specifically.  Ensure that those resources are downloaded, and included in the offline deployment bundle.